### PR TITLE
feat: Remove completely a detector/annotator

### DIFF
--- a/src/api/campaign.controller.ts
+++ b/src/api/campaign.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Delete, Param, Body } from '@nestjs/common';
+import { DetectorService } from '../services/detector.service';
+import { AnnotatorService } from '../services/annotator.service';
+
+@Controller('campaigns')
+export class CampaignController {
+  constructor(private readonly detectorService: DetectorService, private readonly annotatorService: AnnotatorService) {}
+
+  @Delete(':campaignId/detectors/:detectorId')
+  async removeDetector(@Param('campaignId') campaignId: string, @Param('detectorId') detectorId: string) {
+    await this.detectorService.removeDetector(campaignId, detectorId);
+    return { message: 'Detector removed successfully' };
+  }
+
+  @Delete(':campaignId/annotators/:annotatorId')
+  async removeAnnotator(@Param('campaignId') campaignId: string, @Param('annotatorId') annotatorId: string) {
+    await this.annotatorService.removeAnnotator(campaignId, annotatorId);
+    return { message: 'Annotator removed successfully' };
+  }
+}

--- a/src/models/campaign.ts
+++ b/src/models/campaign.ts
@@ -1,0 +1,30 @@
+import { Model, Document } from 'mongoose';
+import { Phase } from './phase.model';
+
+export interface Campaign extends Document {
+  name: string;
+  phases: Phase[];
+  detectors: Detector[];
+  annotators: Annotator[];
+}
+
+export interface Detector {
+  id: string;
+  name: string;
+  enabled: boolean;
+}
+
+export interface Annotator {
+  id: string;
+  name: string;
+  enabled: boolean;
+}
+
+export const CampaignSchema = new Schema({
+  name: { type: String, required: true },
+  phases: [{ type: Schema.Types.ObjectId, ref: 'Phase' }],
+  detectors: [{ type: Detector }],
+  annotators: [{ type: Annotator }],
+});
+
+export const CampaignModel: Model<Campaign> = model('Campaign', CampaignSchema);

--- a/src/services/annotator.service.ts
+++ b/src/services/annotator.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { CampaignModel } from '../models/campaign.model';
+
+@Injectable()
+export class AnnotatorService {
+  async removeAnnotator(campaignId: string, annotatorId: string) {
+    const campaign = await CampaignModel.findById(campaignId);
+    if (!campaign) {
+      throw new Error('Campaign not found');
+    }
+    campaign.annotators = campaign.annotators.filter(annotator => annotator.id !== annotatorId);
+    await campaign.save();
+  }
+}

--- a/src/services/detector.service.ts
+++ b/src/services/detector.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { CampaignModel } from '../models/campaign.model';
+
+@Injectable()
+export class DetectorService {
+  async removeDetector(campaignId: string, detectorId: string) {
+    const campaign = await CampaignModel.findById(campaignId);
+    if (!campaign) {
+      throw new Error('Campaign not found');
+    }
+    campaign.detectors = campaign.detectors.filter(detector => detector.id !== detectorId);
+    await campaign.save();
+  }
+}


### PR DESCRIPTION
## Problem
The current implementation does not provide a mechanism to completely remove a detector/annotator from a campaign/phase.

## Solution
Added Detector and Annotator interfaces and updated CampaignSchema to include detectors and annotators. Created DetectorService and AnnotatorService with removeDetector and removeAnnotator methods respectively. Added removeDetector and removeAnnotator endpoints to CampaignController.

## Testing
Unit tests and integration tests will be written to verify that a detector/annotator can be successfully removed from a campaign/phase.

---
*Closes #463*

> 🤖 Generated by AutoGit